### PR TITLE
Add shebang

### DIFF
--- a/ffmpeg-android-maker.sh
+++ b/ffmpeg-android-maker.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Defining essential directories
 
 # The root of the project


### PR DESCRIPTION
Without it, script fails on systems that have a minimal shell in /bin/sh, like my Pop!_OS and probably Ubuntu too.