### PR TITLE
Fix pkgconfig path

### DIFF
--- a/scripts/ffmpeg/build.sh
+++ b/scripts/ffmpeg/build.sh
@@ -24,8 +24,7 @@ done
 # Referencing dependencies without pkgconfig
 DEP_CFLAGS="-I${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}/include"
 DEP_LD_FLAGS="-L${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}/lib $FFMPEG_EXTRA_LD_FLAGS"
-
-./configure \
+PKG_CONFIG_PATH="${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}/lib/pkgconfig" ./configure \
   --prefix=${BUILD_DIR_FFMPEG}/${ANDROID_ABI} \
   --enable-cross-compile \
   --target-os=android \


### PR DESCRIPTION
Ensures the pkg-config path is set to the correct directory.
This will fix errors like `ERROR: x264 not found using pkg-config` in some environments.