### PR TITLE
Added static build of ffmpeg

### DIFF
--- a/ffmpeg-android-maker.sh
+++ b/ffmpeg-android-maker.sh
@@ -34,7 +34,12 @@ export BUILD_DIR_EXTERNAL=$BUILD_DIR/external
 function prepareOutput() {
   OUTPUT_LIB=${OUTPUT_DIR}/lib/${ANDROID_ABI}
   mkdir -p ${OUTPUT_LIB}
-  cp ${BUILD_DIR_FFMPEG}/${ANDROID_ABI}/lib/*.so ${OUTPUT_LIB}
+  if [ "$ENABLE_SHARED" -eq 1 ]; then
+    cp ${BUILD_DIR_FFMPEG}/${ANDROID_ABI}/lib/*.so ${OUTPUT_LIB}
+  fi
+  if [ "$ENABLE_STATIC" -eq 1 ]; then
+    cp ${BUILD_DIR_FFMPEG}/${ANDROID_ABI}/lib/*.a ${OUTPUT_LIB}
+  fi
 
   OUTPUT_HEADERS=${OUTPUT_DIR}/include/${ANDROID_ABI}
   mkdir -p ${OUTPUT_HEADERS}
@@ -46,7 +51,12 @@ function prepareOutput() {
 # Otherwise the whole script is interrupted
 function checkTextRelocations() {
   TEXT_REL_STATS_FILE=${STATS_DIR}/text-relocations.txt
-  ${FAM_READELF} --dynamic ${BUILD_DIR_FFMPEG}/${ANDROID_ABI}/lib/*.so | grep 'TEXTREL\|File' >> ${TEXT_REL_STATS_FILE}
+  if [ "$ENABLE_SHARED" -eq 1 ]; then
+    ${FAM_READELF} --dynamic ${BUILD_DIR_FFMPEG}/${ANDROID_ABI}/lib/*.so | grep 'TEXTREL\|File' >> ${TEXT_REL_STATS_FILE}
+  fi
+  if [ "$ENABLE_STATIC" -eq 1 ]; then
+    ${FAM_READELF} --dynamic ${BUILD_DIR_FFMPEG}/${ANDROID_ABI}/lib/*.a | grep 'TEXTREL\|File' >> ${TEXT_REL_STATS_FILE}
+  fi
 
   if grep -q TEXTREL ${TEXT_REL_STATS_FILE}; then
     echo "There are text relocations in output files:"

--- a/scripts/ffmpeg/build.sh
+++ b/scripts/ffmpeg/build.sh
@@ -25,6 +25,9 @@ done
 DEP_CFLAGS="-I${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}/include"
 DEP_LD_FLAGS="-L${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}/lib $FFMPEG_EXTRA_LD_FLAGS"
 
+PARAM_SHARED=$([ "$ENABLE_SHARED" -eq 1 ] && echo "--enable-shared" || echo "--disable-shared")
+PARAM_STATIC=$([ "$ENABLE_STATIC" -eq 1 ] && echo "--enable-static" || echo "--disable-static")
+
 ./configure \
   --prefix=${BUILD_DIR_FFMPEG}/${ANDROID_ABI} \
   --enable-cross-compile \
@@ -41,8 +44,8 @@ DEP_LD_FLAGS="-L${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}/lib $FFMPEG_EXTRA_LD_FLAGS"
   --strip=${FAM_STRIP} \
   --extra-cflags="-O3 -fPIC $DEP_CFLAGS" \
   --extra-ldflags="$DEP_LD_FLAGS" \
-  --enable-shared \
-  --disable-static \
+  ${PARAM_SHARED} \
+  ${PARAM_STATIC} \
   --disable-vulkan \
   --pkg-config=${PKG_CONFIG_EXECUTABLE} \
   ${EXTRA_BUILD_CONFIGURATION_FLAGS} \

--- a/scripts/parse-arguments.sh
+++ b/scripts/parse-arguments.sh
@@ -12,6 +12,8 @@ SOURCE_TYPE=TAR
 SOURCE_VALUE=7.0
 EXTERNAL_LIBRARIES=()
 FFMPEG_GPL_ENABLED=false
+ENABLE_SHARED=1
+ENABLE_STATIC=0
 
 # All FREE libraries that are supported
 SUPPORTED_LIBRARIES_FREE=(
@@ -134,6 +136,18 @@ for argument in "$@"; do
   --enable-all-gpl | -all-gpl)
     EXTERNAL_LIBRARIES+=" ${SUPPORTED_LIBRARIES_GPL[@]}"
     FFMPEG_GPL_ENABLED=true
+    ;;
+  --enable-shared)
+    ENABLE_SHARED=1
+    ;;
+  --disable-shared)
+    ENABLE_SHARED=0
+    ;;
+  --enable-static)
+    ENABLE_STATIC=1
+    ;;
+  --disable-static)
+    ENABLE_STATIC=0
     ;;
   *)
     echo "Unknown argument $argument"


### PR DESCRIPTION
This commit adds four params to the build script:

* --enable-shared: shared libraries are built;
* --enable-static: static libraries are built;
* --disable-shared: shared libraries are not built;
* --disable-static: static libraries are not built;

if none is added, shared libraries only are built. It is possible to build both versions at the same time.