### PR TITLE
Add missing dependencies for libxml: autoconf automake & libtool

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -27,6 +27,9 @@ RUN apt-get --allow-releaseinfo-change update && apt-get install -y --no-install
   pkg-config \
   make \
   git \
+  autoconf \
+  automake \
+  libtool \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
I've got the following error:

```
Building the component: libxml2

You must have autoconf installed to compile libxml.
Download the appropriate package for your distribution,
or see http://www.gnu.org/software/autoconf

You must have libtool installed to compile libxml.
Download the appropriate package for your distribution,
or see http://www.gnu.org/software/libtool

You must have automake installed to compile libxml.
Download the appropriate package for your distribution,
or see http://www.gnu.org/software/automake
```

while compiling ffmpeg with the following FAM_ARGS:
```
--source-tar=5.0 --enable-all-gpl --enable-all-free --target-abis=arm64-v8a
```