### PR TITLE
Adds ability to pass in arbitrary config flags from client

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,12 @@ Certain external libraries require additional software to be installed. Check th
 
 ## Features
 
+**Pass extra FFmpeg configuration flags**. You can pass additional flags directly to FFmpeg's `./configure` script using the `--extra-ffmpeg-config-flags` argument. For example:
+```bash
+./ffmpeg-android-maker.sh --extra-ffmpeg-config-flags="--disable-programs --disable-doc"
+```
+This allows you to customize the FFmpeg build without modifying the build scripts.
+
 **Add an arbitrary external library that FFMpeg supports to the building process**. Just specify how the source code needs to be downloaded and how to perform the build operation. More about this is [here](https://github.com/Javernaut/ffmpeg-android-maker/wiki/External-libraries-integration).
 
 **Setting your own FFmpeg version and origin**. You can actually override the version of FFmpeg used by the script. See details [here](https://github.com/Javernaut/ffmpeg-android-maker/wiki/Setting-the-FFmpeg-version).

--- a/scripts/export-build-variables.sh
+++ b/scripts/export-build-variables.sh
@@ -82,7 +82,8 @@ export FAM_YASM=${TOOLCHAIN_PATH}/bin/yasm
 export FFMPEG_EXTRA_LD_FLAGS=
 
 # A variable to which certain dependencies can add addtional arguments during ffmpeg build.sh
-export EXTRA_BUILD_CONFIGURATION_FLAGS=
+# Also includes any user-provided extra configuration flags
+export EXTRA_BUILD_CONFIGURATION_FLAGS=${USER_EXTRA_FFMPEG_CONFIG_FLAGS}
 
 export INSTALL_DIR=${BUILD_DIR_EXTERNAL}/${ANDROID_ABI}
 

--- a/scripts/parse-arguments.sh
+++ b/scripts/parse-arguments.sh
@@ -12,6 +12,7 @@ SOURCE_TYPE=TAR
 SOURCE_VALUE=7.1.2
 EXTERNAL_LIBRARIES=()
 FFMPEG_GPL_ENABLED=false
+USER_EXTRA_CONFIG_FLAGS=""
 
 # All FREE libraries that are supported
 SUPPORTED_LIBRARIES_FREE=(
@@ -121,7 +122,7 @@ for argument in "$@"; do
     ;;
   --enable-libbluray | -bluray)
     EXTERNAL_LIBRARIES+=("libbluray")
-    ;; 
+    ;;
   --enable-libxml2 | -xml2)
     EXTERNAL_LIBRARIES+=("libxml2")
     ;;
@@ -131,6 +132,10 @@ for argument in "$@"; do
   --enable-all-gpl | -all-gpl)
     EXTERNAL_LIBRARIES+=" ${SUPPORTED_LIBRARIES_GPL[@]}"
     FFMPEG_GPL_ENABLED=true
+    ;;
+  # Pass extra FFmpeg configuration flags directly to ./configure
+  --extra-ffmpeg-config-flags=*)
+    USER_EXTRA_CONFIG_FLAGS="${argument#*=}"
     ;;
   *)
     echo "Unknown argument $argument"
@@ -159,3 +164,6 @@ export FFMPEG_EXTERNAL_LIBRARIES=${EXTERNAL_LIBRARIES[@]}
 # Desired Android API level to use during compilation
 # Will be replaced with 21 for 64bit ABIs if the value is less than 21
 export DESIRED_ANDROID_API_LEVEL=${API_LEVEL}
+
+# User-provided extra configuration flags for FFmpeg's ./configure
+export USER_EXTRA_FFMPEG_CONFIG_FLAGS=${USER_EXTRA_CONFIG_FLAGS}


### PR DESCRIPTION
# Problem/Solution
There's no way to pass in the rich set of config flags directly from `ffmpeg-android-maker` API to the ffmpeg configuration. This diff remedies that.


# Test:
```
./ffmpeg-android-maker.sh -abis=arm64 --extra-ffmpeg-config-flags="--disable-everything"
....
❯ ./ffmpeg-android-maker.sh -abis=arm64 --extra-ffmpeg-config-flags="--disable-everything"
Getting source code of the component: ffmpeg
Using FFmpeg source archive: 7.1.2
Ensuring sources of ffmpeg in ffmpeg-7.1.2
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100 12.6M  100 12.6M    0     0  4176k      0  0:00:03  0:00:03 --:--:-- 4177k
Building the component: ffmpeg
install prefix            /Users/anthonybajoua/ffmpeg-android-maker/build/ffmpeg/arm64-v8a
source path               .
C compiler                /opt/android_ndk/toolchains/llvm/prebuilt/darwin-x86_64/bin/aarch64-linux-android21-clang
C library                 bionic
host C compiler           gcc
host C library            
ARCH                      aarch64 (generic)
big-endian                no
runtime cpu detection     yes
NEON enabled              yes
DOTPROD enabled           yes
I8MM enabled              yes
debug symbols             yes
strip symbols             yes
optimize for size         no
optimizations             yes
static                    no
shared                    yes
postprocessing support    no
network support           yes
threading support         pthreads
safe bitstream reader     yes
texi2html enabled         no
perl enabled              yes
pod2man enabled           yes
makeinfo enabled          no
makeinfo supports HTML    no
xmllint enabled           yes

External libraries:
zlib

External libraries providing hardware acceleration:
v4l2_m2m

Libraries:
avcodec                 avfilter                avutil                  swscale
avdevice                avformat                swresample

Programs:
ffmpeg                  ffprobe

Enabled decoders:

Enabled encoders:

Enabled hwaccels:

Enabled parsers:
......
```


